### PR TITLE
Fix StackOverflowException in DescriptionOperationFilter if a type ha…

### DIFF
--- a/WebApi/Controllers/SelfReferencingTypeController.cs
+++ b/WebApi/Controllers/SelfReferencingTypeController.cs
@@ -1,0 +1,69 @@
+﻿using System.Net;
+using System.Web.Http;
+using Swashbuckle.Examples;
+using Swashbuckle.Swagger.Annotations;
+using WebApi.Models;
+using WebApi.Models.Examples;
+
+namespace WebApi.Controllers
+{
+    public class SelfReferencingTypeController : ApiController
+    {
+        [HttpGet]
+        [Route("api/selfReferencingType/load")]
+        
+        [SwaggerResponse(HttpStatusCode.OK, "Successfully retrieved a self referencing type object", typeof(SelfReferencingTypeObjectResponse))]
+        [SwaggerResponseExample(HttpStatusCode.OK, typeof(SelfReferencingTypeObjectResponseExample))]
+        
+        [SwaggerResponse(HttpStatusCode.InternalServerError, "There was an unexpected error")]
+        [SwaggerResponseExample(HttpStatusCode.InternalServerError, typeof(InternalServerResponseExample))]
+        
+        public IHttpActionResult GetNestedObject()
+        {
+            var nestedObjectResponse = new SelfReferencingTypeObjectResponse
+            {
+                TheObject = new SelfReferencingTypeObject
+                {
+                    PropertyWithoutDescription = "this property has no description attribute 1",
+                    PropertyWithDescription = "this property has description attribute 1",
+                    OtherObjectsWithoutPropertyDescription = new[]
+                    {
+                        new SelfReferencingTypeObject
+                        {
+                            PropertyWithoutDescription =
+                                "nested object property 1: this property has no description attribute 1",
+                            PropertyWithDescription =
+                                "nested object property 1: this property has a description attribute 1"
+                        },
+                        new SelfReferencingTypeObject
+                        {
+                            PropertyWithoutDescription =
+                                "nested object property 1: this property has no description attribute 2",
+                            PropertyWithDescription =
+                                "nested object property 1: this property has a description attribute 2"
+                        }
+                    },
+                    OtherObjectsWithPropertyDescription = new[]
+                    {
+                        new SelfReferencingTypeObject
+                        {
+                            PropertyWithoutDescription =
+                                "nested object property 2: this property has no description attribute 1",
+                            PropertyWithDescription =
+                                "nested object property 2: this property has a description attribute 1"
+                        },
+                        new SelfReferencingTypeObject
+                        {
+                            PropertyWithoutDescription =
+                                "nested object property 2: this property has no description attribute 2",
+                            PropertyWithDescription =
+                                "nested object property 2: this property has a description attribute 2"
+                        }
+                    },
+                }
+            };
+            
+            return Ok(nestedObjectResponse);
+        }
+    }
+}

--- a/WebApi/Models/Examples/SelfReferencingTypeObjectResponseExample.cs
+++ b/WebApi/Models/Examples/SelfReferencingTypeObjectResponseExample.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using Swashbuckle.Examples;
+
+namespace WebApi.Models.Examples
+{
+    public class SelfReferencingTypeObjectResponseExample : IExamplesProvider
+    {
+        public object GetExamples()
+        {
+            return new SelfReferencingTypeObjectResponse
+            {
+                TheObject = new SelfReferencingTypeObject
+                {
+                    PropertyWithoutDescription = "propNoDesc1",
+                    PropertyWithDescription = "propWithDesc1",
+                    OtherObjectsWithoutPropertyDescription = new[]
+                    {
+                        new SelfReferencingTypeObject
+                        {
+                            PropertyWithoutDescription = "nestedProp1_propNoDesc1",
+                            PropertyWithDescription = "nestedProp1_propWithDesc1"
+                        },
+                        new SelfReferencingTypeObject
+                        {
+                            PropertyWithoutDescription = "nestedProp1_propNoDesc2",
+                            PropertyWithDescription = "nestedProp1_propWithDesc2"
+                        }
+                    },
+                    OtherObjectsWithPropertyDescription = new[]
+                    {
+                        new SelfReferencingTypeObject
+                        {
+                            PropertyWithoutDescription = "nestedProp2_propNoDesc1",
+                            PropertyWithDescription = "nestedProp2_propWithDesc1"
+                        },
+                        new SelfReferencingTypeObject
+                        {
+                            PropertyWithoutDescription = "nestedProp2_propNoDesc2",
+                            PropertyWithDescription = "nestedProp2_propWithDesc2"
+                        }
+                    },
+                }
+            };
+        }
+    }
+}

--- a/WebApi/Models/SelfReferencingTypeObject.cs
+++ b/WebApi/Models/SelfReferencingTypeObject.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.Serialization;
+
+namespace WebApi.Models
+{
+    [DataContract]
+    public class SelfReferencingTypeObject
+    {
+        [DataMember]
+        public string PropertyWithoutDescription { get; set; }
+        
+        [DataMember]
+        [Description("A property that has a DescriptionAttribute defined")]
+        public string PropertyWithDescription { get; set; }
+
+        [DataMember]
+        public IEnumerable<SelfReferencingTypeObject> OtherObjectsWithoutPropertyDescription { get; set; }
+        
+        [DataMember]
+        [Description("A SelfReferencingTypeObject collection property that has a DescriptionAttribute defined")]
+        public IEnumerable<SelfReferencingTypeObject> OtherObjectsWithPropertyDescription { get; set; }
+    }
+}

--- a/WebApi/Models/SelfReferencingTypeObjectResponse.cs
+++ b/WebApi/Models/SelfReferencingTypeObjectResponse.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel;
+using System.Runtime.Serialization;
+
+namespace WebApi.Models
+{
+    [DataContract]
+    public class SelfReferencingTypeObjectResponse
+    {
+        [DataMember]
+        // defined DescriptionAttribute to ensure that the descriptions of SelfReferencingTypeObject are also updated by the DescriptionOperationFilter
+        [Description("The actual object of a type that has its type also defined as a property")]
+        public SelfReferencingTypeObject TheObject { get; set; }
+    }
+}

--- a/WebApi/WebApi.csproj
+++ b/WebApi/WebApi.csproj
@@ -186,11 +186,13 @@
     <Compile Include="Areas\HelpPage\SampleGeneration\SampleDirection.cs" />
     <Compile Include="Areas\HelpPage\SampleGeneration\TextSample.cs" />
     <Compile Include="Areas\HelpPage\XmlDocumentationProvider.cs" />
+    <Compile Include="Controllers\SelfReferencingTypeController.cs" />
     <Compile Include="Models\DynamicData.cs" />
     <Compile Include="Models\Examples\DictionaryRequestExample.cs" />
     <Compile Include="Models\Examples\DictionaryResponseExample.cs" />
     <Compile Include="Models\Examples\DynamicDataRequestExample.cs" />
     <Compile Include="Models\Examples\DynamicDataResponseExample.cs" />
+    <Compile Include="Models\Examples\SelfReferencingTypeObjectResponseExample.cs" />
     <Compile Include="Models\Examples\NotFoundResponseExample.cs" />
     <Compile Include="Models\Examples\ListPeopleRequestExample.cs" />
     <Compile Include="Models\Examples\WrappedPersonRequestExample.cs" />
@@ -200,6 +202,8 @@
     <Compile Include="Models\ErrorResponse.cs" />
     <Compile Include="Models\Examples\WrappedPersonResponseExample.cs" />
     <Compile Include="Models\Gender.cs" />
+    <Compile Include="Models\SelfReferencingTypeObject.cs" />
+    <Compile Include="Models\SelfReferencingTypeObjectResponse.cs" />
     <Compile Include="Models\PeopleRequest.cs" />
     <Compile Include="Models\PersonRequest.cs" />
     <Compile Include="Controllers\ValuesController.cs" />


### PR DESCRIPTION
The DescriptionOperationFilter could cause a StackOverflowException due to circular calls of the recursive UpdateDescriptions() method. This happens if the used type for an operation parameter or response (in SwaggerResponseAttribute) has a property with its own type defined (see 'SelfReferencingTypeObject' in commit) and this property has a DescriptionAttribute defined - the value descriptions of the very same Schema would be updated again and again until the StackOverflowException is thrown.
A check has been added in UpdateDescription() if the Schema of the current type has already been updated with the descriptions, avoiding multiple/infinite updates.
I've also added a new type 'SelfReferencingTypeObjectResponse' holding the 'SelfReferencingTypeObject' and a controller method to illustrate/verify the issue.